### PR TITLE
サイトタイトルの変更と、但し書きの変更

### DIFF
--- a/views/index.php
+++ b/views/index.php
@@ -3,7 +3,7 @@
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#  website: http://ogp.me/ns/website#">
     <meta charset="utf-8">
-    <title>Watermap</title>
+    <title>MIZUDERU.INFO</title>
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
     <meta name="keywords" content="熊本地震,給水,みずでる,水道">
     <meta http-equiv="content-style-type" content="text/css">

--- a/views/post.php
+++ b/views/post.php
@@ -28,7 +28,7 @@
         <a href="javascript:void(0)" onclick="now()">現在位置を設定</a>
         <br>
         <br>
-        <span class="memo">位置情報の設定できない場合，本体の設定から位置情報の利用を許可してください．</span>
+        <span class="memo">本体の設定から位置情報の利用を許可してください．</span>
     </div>
 <!--    <div class="box">-->
 <!--        <span class="memo">画像アップロード</span><br>-->


### PR DESCRIPTION
「位置情報の設定できない場合，本体の設定から位置情報の利用を許可してください．」が長すぎて2行になってた。そこでカンマより前を削除。また、タイトルはわかり易い名前「MIZUDERU.INFO」に変えた。
