### PR TITLE
画像のチェックを追加

### DIFF
--- a/config/validate.php
+++ b/config/validate.php
@@ -40,3 +40,20 @@ function IsLocateString($locate) {
 function IsUrl($url) {
     return filter_var($url, FILTER_VALIDATE_URL) !== false;
 }
+
+/**
+ * 画像かどうかチェックする
+ * @param file
+ *
+ * @return boolean
+ */
+function IsImage($file) {
+    if (preg_match("/.*\.(jpe?g|gif|png)$/", strtolower($file['name'])) !== 1) {
+        return false;
+    }
+    $type = @exif_imagetype($file['tmp_name']);
+    if (!in_array($type, [IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG], true)) {
+        return false;
+    }
+    return true;
+}

--- a/webroot/rousui_post.php
+++ b/webroot/rousui_post.php
@@ -32,7 +32,7 @@ if( isset( $_POST['submit'] ) ){
             }
         }
 
-        if ($image_url === "") {
+        if ($image_url !== "") {
 
             $query = array(
                 "latlng" => h($locate),

--- a/webroot/rousui_post.php
+++ b/webroot/rousui_post.php
@@ -20,33 +20,41 @@ if( isset( $_POST['submit'] ) ){
             if (!is_uploaded_file($file["tmp_name"])) {
                 die('ファイルがアップロードされていません');
             }
+
+            if (!IsImage($file)) {
+                die('画像はJPEG(jpg,jpeg)、GIF(gif)、PNG(png)のいずれかとなっております。');
+            }
+
             $result = s3Upload($file, '');
-            
+
             if($result){
                 $image_url = $result['ObjectURL'];
             }
         }
 
-        $query = array(
-            "latlng" => h($locate),
-            "language" => "ja",
-            "sensor" => false
-        );
-        $res = callApi("GET", "https://maps.googleapis.com/maps/api/geocode/json", $query);
+        if ($image_url === "") {
 
-        $address= $res["results"][0]["formatted_address"];
+            $query = array(
+                "latlng" => h($locate),
+                "language" => "ja",
+                "sensor" => false
+            );
+            $res = callApi("GET", "https://maps.googleapis.com/maps/api/geocode/json", $query);
 
-        $sql = "INSERT INTO rousui SET time = :time, locate = :locate, comment = :comment, image_url = :image_url, address = :address, flg = :flg";
-        $params = ["time"    => $time ,
-            "locate"  => $locate ,
-            "comment" => $comment ,
-            "image_url" => $image_url,
-            "address" => $address,
-            "flg" => 4,
-        ];
+            $address= $res["results"][0]["formatted_address"];
 
-        DB::conn()->query($sql , $params);
-        header('Location: index.php');
+            $sql = "INSERT INTO rousui SET time = :time, locate = :locate, comment = :comment, image_url = :image_url, address = :address, flg = :flg";
+            $params = ["time"    => $time ,
+                "locate"  => $locate ,
+                "comment" => $comment ,
+                "image_url" => $image_url,
+                "address" => $address,
+                "flg" => 4,
+            ];
+
+            DB::conn()->query($sql , $params);
+            header('Location: index.php');
+        }
     }
     echo $err .PHP_EOL;
 }


### PR DESCRIPTION
例によってとりあえず対応版です。

使用している `exif_imagetype` 関数はたしか先頭の数byteだけで判定するので完璧なチェックには使えなかったはず。
PHPのブランクありすぎて完璧なチェックの正しい実装が思い出せないので 一旦これで。

あと、S3のアップロードに失敗した時にもINSERTしようとして落ちるような気がするので修正しました（チェックの確認はしましたがここについては未確認）
