### PR TITLE
Memcached セッション機構

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ docker-compose up -d
 下記の通りローカルに立ち上がる
 - apache + php5.6が `80` ポート
 - MySQLが `3306` ポート
+- Memcachedが `11211` ポート
 
 ### MySQLのスキーマ準備
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,7 +20,15 @@ require_once (CONFIG_DIR . "/env.php");
 require_once (VENDOR_DIR. "/SimpleDBI/SimpleDBI.php");
 require_once (CONFIG_DIR . "/db.php");
 require_once (CONFIG_DIR . "/template.php");
+require_once (CONFIG_DIR . "/session.php");
 require_once (CONFIG_DIR . "/validate.php");
 require_once (CONFIG_DIR . "/files.php");
 require_once (CONFIG_DIR . "/helper.php");
 require_once (VENDOR_DIR . '/autoload.php');
+
+SessionManager::configure(new MemcachedSessionSetting(array(
+    'save_path' => getenv('SESSION_SAVE_PATH'),
+    'maxlifetime' => getenv('SESSION_LIFETIME'),
+)));
+
+SessionManager::start();

--- a/config/session.php
+++ b/config/session.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Class SessionSetting
+ */
+ abstract class SessionSetting
+ {
+    protected $settings;
+
+    public function __construct(array $settings) {
+        $this->settings = $settings;
+    }
+
+    abstract public function initialize();
+ }
+
+
+class MemcachedSessionSetting extends SessionSetting
+{
+    public function initialize()
+    {
+        ini_set('session.save_handler', 'memcached');
+        ini_set('session.save_path', $this->settings['save_path']);
+        ini_set('session.gc_maxlifetime', $this->settings['maxlifetime']);
+    }
+}
+
+ /**
+  * Class SessionManager
+  */
+class SessionManager
+{
+    private static $setting;
+
+    public static function configure(SessionSetting $setting)
+    {
+        self::$setting = $setting;
+    }
+
+    public static function start()
+    {
+        self::$setting->initialize();
+        session_start();
+    }
+
+    public static function destroy()
+    {
+        session_destroy();
+    }
+
+    public static function regenerate($delete_old_session = false)
+    {
+        session_regenerate_id($delete_old_session);
+    }
+}
+
+
+ /**
+  * Class Session
+  */
+class Session
+{
+    public static function get($key)
+    {
+        return $_SESSION[$key];
+    }
+
+    public static function set($key, $val)
+    {
+        return $_SESSION[$key] = $val;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,15 @@ php56:
     DB_PORT: 3306
     DB_USERNAME: root
     DB_PASSWORD: password
+    SESSION_SAVE_PATH: 127.0.0.1:11211
+    SESSION_LIFETIME: 3600
 
 mysql56:
   image: mysql:5.6
   net: host
   environment:
     MYSQL_ROOT_PASSWORD: password
+
+memcached:
+  image: memcached:1.4
+  net: host

--- a/docker-php56/Dockerfile
+++ b/docker-php56/Dockerfile
@@ -1,3 +1,5 @@
 FROM php:5.6-apache
-RUN apt-get update && apt-get install -y libmysqlclient-dev \
+RUN apt-get update && apt-get install -y libmysqlclient-dev libmemcached-dev \
     && docker-php-ext-install pdo pdo_mysql \
+    && pecl install memcached \
+    && docker-php-ext-enable memcached \


### PR DESCRIPTION
Fix #37 

Memcachedによるセッション機構を実装しました。

これを使用するためには以下のタスクが必要です。
- ElastiCache for Memcachedの構築
- 上で構築したElastiCacheエンドポイントを使って `SESSION_SAVE_PATH` 環境変数に `<endpoint>:<port>` の形式で設定  
  ※2台以上のクラスターの場合はカンマ区切りで列挙  
  http://php.net/manual/ja/memcached.sessions.php
- セッション有効期限を決めて `SESSION_LIFETIME` 環境変数にセット

（環境変数はデプロイ時に`.env.elasticbeanstalk`に記述するのかな？）

ほぼAWS的な話になるので、どなたかサポートお願いします＞JAWSな方々
