### PR TITLE
index.php で操作しなかった場合でもマップが表示されるよう修正

### DIFF
--- a/webroot/js/post.js
+++ b/webroot/js/post.js
@@ -20,18 +20,16 @@
         document.getElementById('now').style.display = 'none';
     var mapDom = document.getElementById('map');
 
-    var currentMap; // 前の画面から表示データを取得する
-    try {
-        currentMap = JSON.parse(sessionStorage.getItem('google-map-post-location'));
-    } catch (e) {
-        console.error(e);
-    }
+    var data   = JSON.parse( sessionStorage.getItem( 'google-map-post-location' ) ),
+        center = new google.maps.LatLng(data ? data.lat : 32.7858659, data ? data.lng : 130.7633434 ),
+        zoom   = data ? data.zoom : 9
 
     var map = new google.maps.Map(mapDom, {
-        center: new google.maps.LatLng(currentMap.lat || 32.7858659, currentMap.lng || 130.7633434),
-        zoom: currentMap.zoom || 9,
+        center: center,
+        zoom: zoom,
         mapTypeId: google.maps.MapTypeId.ROADMAP
     });
+    
     mapDom.style.width = window.innerWidth + 'px';
     mapDom.style.height = window.innerHeight - (document.getElementById('post').clientHeight) - 80 + 'px';
 


### PR DESCRIPTION
> Google Chromeで確認。
> index.jsではzoom_changedと画面遷移のボタンがクリックされるタイミングでセッションストレージにGoogle Mapの設定（中心の緯度・経度とズーム）を保存しようとしているが、うまく機能していない。
> 水漏れ投稿ページへのリンクが増えたため、index.phpのHTMLの #js-post-buttonのIDが被ってしまっているのが原因。
> post.jsでセッションストレージから情報が読み取れなかった時のフォールバックも追加したほうがよさそう。

post.js でストレージの情報がない場合，デフォルトの値を読み込むように修正．
