### PR TITLE
ストレージへの保存がうまくできるように修正

### DIFF
--- a/webroot/js/index.js
+++ b/webroot/js/index.js
@@ -142,10 +142,13 @@ function plotData(t_position) {
         setStorage()
     });
 
-    $('#js-post-button').click(function (event) {
-        setStorage()
-        console.log('google-map-post-location', sessionStorage.getItem('google-map-post-location'));
-    });
+    var setStorageDom = document.getElementsByClassName( 'post-button' )
+    for( var i=0; i<setStorageDom.length; i++ ){
+        setStorageDom[i].addEventListener( 'click', function(){
+            setStorage()
+            console.log('google-map-post-location', sessionStorage.getItem('google-map-post-location'));
+        } )
+    }
 
     // document.getElementById('small').addEventListener('click', function () {
     //     if (map.zoom > 0) map.setZoom(--map.zoom)


### PR DESCRIPTION
> Google Chromeで確認。
> index.jsではzoom_changedと画面遷移のボタンがクリックされるタイミングでセッションストレージにGoogle Mapの設定（中心の緯度・経度とズーム）を保存しようとしているが、うまく機能していない。
> 水漏れ投稿ページへのリンクが増えたため、index.phpのHTMLの #js-post-buttonのIDが被ってしまっているのが原因。
> post.jsでセッションストレージから情報が読み取れなかった時のフォールバックも追加したほうがよさそう。

post-button クラスを指定することでクリックされた時，座標とズーム情報を保存するように変更．
