### PR TITLE
CSRF対策追加

### DIFF
--- a/auth/AntiCSRF.php
+++ b/auth/AntiCSRF.php
@@ -1,0 +1,62 @@
+<?php namespace Mizuderu\Auth;
+
+class AntiCSRF {
+
+    const SALT_ENV_KEY = 'ANTI_CSRF_SALT';
+
+    /**
+     * @var string
+     */
+    private $salt;
+
+    /**
+     * @var string
+     */
+    private $algorithm;
+
+    /**
+     * .envの設定から作成
+     * @return AntiCSRF
+     */
+    public static function fromEnv()
+    {
+        return new self(getenv('ANTI_CSRF_SALT'));
+    }
+
+    /**
+     * AntiCSRF constructor.
+     * @param string $salt
+     * @param string $algorithm
+     */
+    public function __construct($salt, $algorithm = 'sha256')
+    {
+        if(!is_string($salt) || empty($salt)) {
+            throw new \InvalidArgumentException('saltは空でない文字列で指定してください。');
+        }
+
+        $this->salt = $salt;
+        $this->algorithm = $algorithm;
+    }
+
+    /**
+     * CSRF対策トークンを生成
+     * @return string
+     */
+    public function generateToken() {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            throw new \BadMethodCallException('セッションがアクティブではありません。');
+        }
+
+        return hash($this->algorithm, session_id() . $this->salt);
+    }
+
+    /**
+     * CSRF対策トークンの妥当性を検証
+     * @param string $token
+     * @return bool
+     */
+    public function validate($token)
+    {
+        return $this->generateToken() === $token;
+    }
+}

--- a/auth/AntiCSRF.php
+++ b/auth/AntiCSRF.php
@@ -2,8 +2,6 @@
 
 class AntiCSRF {
 
-    const SALT_ENV_KEY = 'ANTI_CSRF_SALT';
-
     /**
      * @var string
      */

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -32,3 +32,8 @@ SessionManager::configure(new MemcachedSessionSetting(array(
 )));
 
 SessionManager::start();
+
+// anti csrf protection
+if(in_array($_SERVER['REQUEST_METHOD'], ['POST', 'PUT', 'DELETE'])) {
+    validateCsrfTokenOrDie();
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -34,6 +34,6 @@ SessionManager::configure(new MemcachedSessionSetting(array(
 SessionManager::start();
 
 // anti csrf protection
-if(in_array($_SERVER['REQUEST_METHOD'], ['POST', 'PUT', 'DELETE'])) {
+if(in_array($_SERVER['REQUEST_METHOD'], ['POST', 'PUT', 'DELETE', 'PATCH'])) {
     validateCsrfTokenOrDie();
 }

--- a/config/helper.php
+++ b/config/helper.php
@@ -165,3 +165,28 @@ function callApi($method, $url, $data = false){
 
     return json_decode($result, true);
 }
+
+use Mizuderu\Auth\AntiCSRF;
+
+/**
+ * CSRF対策トークンを生成
+ *
+ * @return string
+ */
+function csrfToken()
+{
+    return AntiCSRF::fromEnv()->generateToken();
+}
+
+/**
+ * CSRF対策トークンを検証
+ * 不正ならステータスコード400でレスポンスを返す
+ */
+function validateCsrfTokenOrDie()
+{
+    $token = filter_input(INPUT_POST, '_token');
+    if(!AntiCSRF::fromEnv()->validate($token)) {
+        header('Content-Type: text/plain; charset=UTF-8', true, 400);
+        die('不正なリクエストです。');
+    }
+}

--- a/config/helper.php
+++ b/config/helper.php
@@ -166,6 +166,8 @@ function callApi($method, $url, $data = false){
     return json_decode($result, true);
 }
 
+
+require_once AUTH_DIR . '/AntiCSRF.php';
 use Mizuderu\Auth\AntiCSRF;
 
 /**

--- a/config/template.php
+++ b/config/template.php
@@ -16,12 +16,20 @@ abstract class BaseTemplate
  */
 class TwigTemplate extends BaseTemplate
 {
-    public function __construct()
+    /**
+     * コンストラクタ
+     * @param Twig_SimpleFunction[] $functions
+     */
+    public function __construct(array $functions = [])
     {
         $this->template = new Twig_Environment(
             new Twig_Loader_Filesystem(VIEW_DIR),
             array('autoescape' => true)
         );
+
+        foreach($functions as $func) {
+            $this->template->addFunction($func);
+        }
     }
 
     public function render($template, $args)
@@ -45,7 +53,9 @@ class Template
     public static function factory()
     {
         if (is_null(self::$instance)) {
-            self::$instance = new TwigTemplate();
+            self::$instance = new TwigTemplate([
+                new Twig_SimpleFunction('csrfToken', 'csrfToken')
+            ]);
         }
         return self::$instance;
     }

--- a/views/delete.html
+++ b/views/delete.html
@@ -29,6 +29,7 @@
     <h4>この情報を削除してもよろしいですか？</h4>
     <br>
     <form name='del' method='POST' action='delete.php'>
+        <input type=hidden name='_token' value='{{ csrfToken() }}'>
         <input type=hidden name='post_time' value='{{ post_time }}'>
         <input type=hidden name='del_flg' value='yes'>
         <input type='submit' name='submit' value='削除'/>

--- a/views/index.html
+++ b/views/index.html
@@ -8,6 +8,7 @@
     <meta name="keywords" content="熊本地震,給水,みずでる,水道">
     <meta http-equiv="content-style-type" content="text/css">
     <meta http-equiv="content-script-type" content="text/javascript">
+    <meta name="csrf-token" content="{{ csrfToken() }}">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
     <link rel="stylesheet" href="css/owl.carousel.css">
     <link rel="stylesheet" href="css/base.css">

--- a/views/news_post.html
+++ b/views/news_post.html
@@ -14,6 +14,7 @@
 <body>
 {% include "analyticstracking.html" %}
 <form action="{{ php_self }}" method="POST" id="post" onsubmit="return confirm('送信してもいいですか？');">
+    <input type="hidden" name="_token" value="{{ csrfToken() }}">
     <br>
     <h2>ニュース</h2>
     <div class="box">

--- a/views/post.html
+++ b/views/post.html
@@ -30,6 +30,7 @@
     水道から水が出ていますか？
 </div>
 <form action="{{ php_self }}" method="POST" id="post" onsubmit="return confirm('送信してもいいですか？');">
+    <input type="hidden" name="_token" value="{{ csrfToken() }}">
     <input type="hidden" id="time" name="time" value="">
     <input type="hidden" name="locate" id="locate" value="">
 

--- a/views/resolve.html
+++ b/views/resolve.html
@@ -29,6 +29,7 @@
     <h4>この情報を解決済みにしてもよろしいですか？</h4>
     <br>
     <form name='resolve' method='POST' action='resolve.php'>
+        <input type=hidden name='_token' value='{{ csrfToken() }}'>
         <input type=hidden name='post_time' value='{{ post_time }}'>
         <input type=hidden name='resolve_flg' value='yes'>
         <input type='submit' name='submit' value='解決済みにする'/>

--- a/views/rousui_post.html
+++ b/views/rousui_post.html
@@ -30,6 +30,7 @@
     水漏れを報告してください
 </div>
 <form action="{{ php_self }}" enctype="multipart/form-data" method="POST" id="post" onsubmit="return confirm('送信してもいいですか？');">
+    <input type="hidden" name="_token" value="{{ csrfToken() }}">
     <input type="hidden" id="time" name="time" value="">
     <input type="hidden" name="locate" id="locate" value="">
 

--- a/webroot/js/index.js
+++ b/webroot/js/index.js
@@ -5,6 +5,7 @@ var tools_height = document.getElementById('tools').clientHeight;
 function attachMessage(marker, post_time, flg, comment, rousui_image_url, rousui_status) {
     google.maps.event.addListener(marker, 'click', function (event) {
 
+        var csrf_token = $("meta[name='csrf-token']").attr("content");
         var t = new Date(post_time * 1000);
 
         var year = t.getFullYear();
@@ -43,7 +44,7 @@ function attachMessage(marker, post_time, flg, comment, rousui_image_url, rousui
         var resolve_str = "";
         // 漏水の画像があるなら表示
         if(flg == "rousui" && rousui_status != 1){
-            resolve_str = "<br>" + "<a href='' onclick='document.resolve.submit();return false;'>解決済みにする</a>" + "<form name='resolve' method='POST' action='resolve.php'>" + "<input type=hidden name='post_time' value='" + post_time +"'> ";
+            resolve_str = "<br>" + "<a href='' onclick='document.resolve.submit();return false;'>解決済みにする</a>" + "<form name='resolve' method='POST' action='resolve.php'>" + "<input type=hidden name='_token' value='" + csrf_token +"'> " + "<input type=hidden name='post_time' value='" + post_time +"'> ";
         }
 
         var rousui_img = "";
@@ -57,7 +58,6 @@ function attachMessage(marker, post_time, flg, comment, rousui_image_url, rousui
         //5分以内なら削除可能
         if(flg != "rousui" && parseInt(now.getTime() / 1000) < (parseInt(post_time) + (60 * 5))){
 
-            var csrf_token = $("meta[name='csrf-token']").attr("content");
             del_str = "<br><br>" + "<a href='' onclick='document.del.submit();return false;'>この情報を削除する</a>" + "<form name='del' method='POST' action='delete.php'>" + "<input type=hidden name='_token' value='" + csrf_token +"'> " + "<input type=hidden name='post_time' value='" + post_time +"'> ";
         }
 

--- a/webroot/js/index.js
+++ b/webroot/js/index.js
@@ -56,7 +56,9 @@ function attachMessage(marker, post_time, flg, comment, rousui_image_url, rousui
         var del_str = "";
         //5分以内なら削除可能
         if(flg != "rousui" && parseInt(now.getTime() / 1000) < (parseInt(post_time) + (60 * 5))){
-            del_str = "<br><br>" + "<a href='' onclick='document.del.submit();return false;'>この情報を削除する</a>" + "<form name='del' method='POST' action='delete.php'>" + "<input type=hidden name='post_time' value='" + post_time +"'> ";
+
+            var csrf_token = $("meta[name='csrf-token']").attr("content");
+            del_str = "<br><br>" + "<a href='' onclick='document.del.submit();return false;'>この情報を削除する</a>" + "<form name='del' method='POST' action='delete.php'>" + "<input type=hidden name='_token' value='" + csrf_token +"'> " + "<input type=hidden name='post_time' value='" + post_time +"'> ";
         }
 
         new google.maps.Geocoder().geocode({


### PR DESCRIPTION
https://github.com/shinobushiva/Water/issues/35 の一部

中身はクラスで書いてますが、利用は関数使うだけの想定です。
- CSRFチェック用の関数追加
- Twigにテンプレートで使えるCSRFトークン生成関数追加

.envにsalt(推測しにくい文字列)の設定が必要です。キーはANTI_CSRF_SALT

HTTPメソッドが安全でないPOST、PUT、DELETEの時にCSRF対策トークンの妥当性をチェックする処理をbootstrap.phpに追加しました。
POSTで投稿しているところは下記５箇所だと思うのですがもし抜けていたらご指摘ください。

・index.phpからdelete.phpへの遷移
・delete.php
・post.php
・rousui_post.php
・news_post.php
